### PR TITLE
Use BidRequest.User.buyeruid instead of customdata

### DIFF
--- a/doubleclick-openrtb/src/main/java/com/google/doubleclick/openrtb/DoubleClickOpenRtbMapper.java
+++ b/doubleclick-openrtb/src/main/java/com/google/doubleclick/openrtb/DoubleClickOpenRtbMapper.java
@@ -308,7 +308,7 @@ public class DoubleClickOpenRtbMapper implements OpenRtbMapper<
       ByteString dcHMD = coppa
           ? dcRequest.getConstrainedUsageHostedMatchData()
           : dcRequest.getHostedMatchData();
-      user.setCustomdata(BaseEncoding.base16().encode(dcHMD.toByteArray()));
+      user.setBuyeruid(dcHMD.toStringUtf8());
     }
 
     if (dcRequest.hasUserDemographic()) {

--- a/doubleclick-openrtb/src/test/java/com/google/doubleclick/openrtb/DoubleClickOpenRtbMapperTest.java
+++ b/doubleclick-openrtb/src/test/java/com/google/doubleclick/openrtb/DoubleClickOpenRtbMapperTest.java
@@ -36,6 +36,7 @@ import com.google.openrtb.OpenRtb.BidRequest.Impression.PMP;
 import com.google.openrtb.OpenRtb.BidResponse;
 import com.google.openrtb.OpenRtb.BidResponse.SeatBid;
 import com.google.openrtb.OpenRtb.BidResponse.SeatBid.Bid;
+import com.google.protobuf.ByteString;
 import com.google.protos.adx.NetworkBid;
 import com.google.protos.adx.NetworkBid.BidRequest.AdSlot;
 import com.google.protos.adx.NetworkBid.BidResponse.Ad;
@@ -248,7 +249,7 @@ public class DoubleClickOpenRtbMapperTest {
         assertEquals(testDesc, coppa, request.getRegs().getCoppa());
         assertEquals(
             coppa ? "" : "EC22E69CC8B04ACABB6CD4DA88FB33B6",
-            request.getUser().getCustomdata());
+            request.getUser().getBuyeruid());
 
         if (size == TestData.NO_SLOT) {
           assertEquals(0, request.getImpCount());

--- a/doubleclick-openrtb/src/test/java/com/google/doubleclick/openrtb/TestData.java
+++ b/doubleclick-openrtb/src/test/java/com/google/doubleclick/openrtb/TestData.java
@@ -47,6 +47,7 @@ import java.util.List;
 
 public class TestData {
   static final int NO_SLOT = -1;
+  public static final ByteString HOSTED_MATCH_ID = ByteString.copyFromUtf8("EC22E69CC8B04ACABB6CD4DA88FB33B6");
 
   public static Bid.Builder newBid(boolean full) {
     Bid.Builder bid = Bid.newBuilder()
@@ -183,12 +184,7 @@ public class TestData {
       req.setConstrainedUsageHostedMatchData(ByteString.EMPTY);
     } else {
       req.setGoogleUserId("john");
-      req.setHostedMatchData(ByteString.copyFrom(new byte[]{
-          (byte) 0xEC, (byte) 0x22, (byte) 0xE6, (byte) 0x9C,
-          (byte) 0xC8, (byte) 0xB0, (byte) 0x4A, (byte) 0xCA,
-          (byte) 0xBB, (byte) 0x6C, (byte) 0xD4, (byte) 0xDA,
-          (byte) 0x88, (byte) 0xFB, (byte) 0x33, (byte) 0xB6
-      }));
+      req.setHostedMatchData(HOSTED_MATCH_ID);
     }
     return req;
   }


### PR DESCRIPTION
    * Per discussion in thread[1] this PR sugguests use of buyeruid
      instead of customdata to map "Hosted Match Data"

[1]: https://groups.google.com/d/msg/google-open-bidder-discussion/8mUHnz1MvKs/_zgAhkvOkRcJ
[2]: http://www.iab.net/media/file/OpenRTBAPISpecificationVersion2_2.pdf, Page 33