### PR TITLE
Checking if playback method is null before attempting to add it

### DIFF
--- a/doubleclick-openrtb/src/main/java/com/google/doubleclick/openrtb/DoubleClickOpenRtbMapper.java
+++ b/doubleclick-openrtb/src/main/java/com/google/doubleclick/openrtb/DoubleClickOpenRtbMapper.java
@@ -720,7 +720,10 @@ public class DoubleClickOpenRtbMapper implements OpenRtbMapper<
     }
 
     if (dcVideo.hasPlaybackMethod()) {
-      video.addPlaybackmethod(VideoPlaybackMethodMapper.toOpenRtb(dcVideo.getPlaybackMethod()));
+      Video.VideoPlaybackMethod playbackMethod = VideoPlaybackMethodMapper.toOpenRtb(dcVideo.getPlaybackMethod());
+      if (playbackMethod != null) {
+        video.addPlaybackmethod(playbackMethod);
+      }
     }
 
     if (dcSlot.hasSlotVisibility()) {


### PR DESCRIPTION
The mapper is throwing a `NullPointerException` when dealing with bid requests for video opportunities.

From Adx spec we have the following regarding Playback Method:

```java
// Describes how the ad was played.
enum VideoPlaybackMethod {
  METHOD_UNKNOWN = 0;
  AUTO_PLAY_SOUND_ON = 1;
  AUTO_PLAY_SOUND_OFF = 2;
  CLICK_TO_PLAY = 3;
};
optional VideoPlaybackMethod playback_method = 14 [default = METHOD_UNKNOWN];
```

This field is optional and the default value is unknown. 

Then, the static method `VideoPlaybackMethodMapper.toOpenRtb` returns `null` for the default value (unknown) when mapping video requests.

Well, the *OpenRtb* `Video.Builder.addPlaybackmethod` does not allow `null` values:

```java
public OpenRtb.BidRequest.Imp.Video.Builder addPlaybackmethod(OpenRtb.BidRequest.Imp.Video.VideoPlaybackMethod value) {
  if(value == null) {
    throw new NullPointerException();
  } else {
    this.ensurePlaybackmethodIsMutable();
    this.playbackmethod_.add(value);
    this.onChanged();
    return this;
  }
}
```

Therefore, it is necessary to add the check to prevent adding the playback method when the value is `null`.