### PR TITLE
Add CCPA Compliance field to RegsExt

### DIFF
--- a/doubleclick-openrtb/src/main/protobuf/openrtb-adx.proto
+++ b/doubleclick-openrtb/src/main/protobuf/openrtb-adx.proto
@@ -410,6 +410,9 @@ message RegsExt {
   // an EEA user, based on information available to Google. It does not
   // constitute legal guidance on GDPR.
   optional bool gdpr = 1;
+  
+  // OpenRTB Extension for US Privacy (CCPA)
+  optional string us_privacy = 2;  
 }
 
 extend com.google.openrtb.BidRequest.Regs {


### PR DESCRIPTION
The OpenRTB extension for US Privacy provides a field for CCPA compliance:
https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/Version%201.0/OpenRTB%20Extension%20for%20USPrivacy.md