### PR TITLE
Revert "Add CCPA Compliance field to RegsExt"

### DIFF
--- a/doubleclick-openrtb/src/main/protobuf/openrtb-adx.proto
+++ b/doubleclick-openrtb/src/main/protobuf/openrtb-adx.proto
@@ -410,9 +410,6 @@ message RegsExt {
   // an EEA user, based on information available to Google. It does not
   // constitute legal guidance on GDPR.
   optional bool gdpr = 1;
-  
-  // OpenRTB Extension for US Privacy (CCPA)
-  optional string us_privacy = 2;  
 }
 
 extend com.google.openrtb.BidRequest.Regs {


### PR DESCRIPTION
Reverts google/openrtb-doubleclick#147

Removed to prevent confusion, since this field is not populated on bid requests sent by Google. For additional information on how Google works with the IAB CCPA Framework Technical Specifications please refer to this [Help Center article](https://support.google.com/admanager/answer/9603027).